### PR TITLE
Fix for empty cmd param error

### DIFF
--- a/flask.json
+++ b/flask.json
@@ -17,7 +17,6 @@
 			],
 			"mem": 256,
 			"image": "sloppy/nginx",
-			"cmd": "",
 			"instances": 1,
 			"env": {
 					"URI": "$URI",
@@ -34,7 +33,6 @@
 			"id": "flask",
 			"mem": 128,
 			"image": "sloppy/flask",
-			"cmd": "",
 			"instances": 1,
 			"env": {
 					"URIBACKEND": "flask.backend.$PROJECT.$USERNAME",

--- a/flask.json
+++ b/flask.json
@@ -7,7 +7,6 @@
 			"domain": {
 					"type": "HTTP",
 					"uri": "$URI"
-					
 			},
 			"volumes": [],
 			"port_mappings": [


### PR DESCRIPTION
Hi,

The lines `"CMD":  ""` caused an error message and failed command for me.
It is possible that this is merely a validation issue in sloppy.exe. If so please ignore this pull request.

Hope this helps,

Chris
